### PR TITLE
Nav logo

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -175,6 +175,7 @@ class App extends React.Component {
           <NavBar
             displayAllOfType={this.displayAllOfType}
             showSplashPage={this.state.showSplashPage}
+            displaySplashPage={this.displaySplashPage}
             displayAllSearchResults={this.displayAllSearchResults}
             searchBarDisplay={this.state.showCardPage}
             updateSearchResults={this.updateSearchResults}

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -9,11 +9,15 @@ class NavBar extends React.Component {
   }
 
   render() {
+    let navLogo = <h2 className="navLogo">Queenly</h2>
+    let searchBar = <SearchBar {...this.props} />
+
     if (!this.props.showSplashPage) {
       return (
         <nav className="NavBar">
           <Hamburger {...this.props} />
-          <SearchBar {...this.props} />
+          {navLogo}
+          {searchBar}
           <Favorites {...this.props} />
         </nav>
       );

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -9,26 +9,19 @@ class NavBar extends React.Component {
   }
 
   render() {
-    let navLogo = <h2 className="navLogo">Queenly</h2>
-    let searchBar = <SearchBar {...this.props} />
-
     if (!this.props.showSplashPage) {
-      return (
-        <nav className="NavBar">
-          <Hamburger {...this.props} />
-          {navLogo}
-          {searchBar}
-          <Favorites {...this.props} />
-        </nav>
-      );
-    } else {
-      return (
-        <nav className="NavBar">
-          <Hamburger {...this.props} />
-          <Favorites {...this.props} />
-        </nav>
-      );
+      var navLogo = <h2 className="navLogo">Queenly</h2> 
+      var searchBar = <SearchBar {...this.props} />
     }
+
+    return (
+      <nav className="NavBar">
+        <Hamburger {...this.props} />
+        {navLogo}
+        {searchBar}
+        <Favorites {...this.props} />
+      </nav>
+    );
   }
 }
 

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -3,14 +3,21 @@ import Hamburger from "./Hamburger";
 import Favorites from "./Favorites";
 import "../css/NavBar.css";
 import SearchBar from "./SearchBar";
+
 class NavBar extends React.Component {
   constructor(props) {
     super(props);
   }
 
+  displaySplashPage = () => {
+    this.props.displaySplashPage();
+  }
+
   render() {
     if (!this.props.showSplashPage) {
-      var navLogo = <h2 className="navLogo">Queenly</h2> 
+      var navLogo = 
+        <h2 className="navLogo"
+            onClick={this.displaySplashPage}>Queenly</h2> 
       var searchBar = <SearchBar {...this.props} />
     }
 

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -13,7 +13,7 @@ export default class SearchResults extends Component {
 
     if (this.props.searchResults.length === 0) {
       results = 
-        <h2>Nothing to see here.</h2>
+        <h2>No results found.</h2>
     } else {
       results = this.props.searchResults.map(result => (
         <Thumbnail

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -13,7 +13,7 @@ export default class SearchResults extends Component {
 
     if (this.props.searchResults.length === 0) {
       results = 
-        <h2>No results found.</h2>
+        <h2>Nothing to see here.</h2>
     } else {
       results = this.props.searchResults.map(result => (
         <Thumbnail

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -12,9 +12,8 @@ export default class SearchResults extends Component {
     let results;
 
     if (this.props.searchResults.length === 0) {
-      results = (
-        <h2>Please Broaden Your Search</h2>
-      )
+      results = 
+        <h2>No results found.</h2>
     } else {
       results = this.props.searchResults.map(result => (
         <Thumbnail
@@ -27,7 +26,7 @@ export default class SearchResults extends Component {
     }
 
     if (this.props.searchQuery) {
-      var resultsHeader = <h3>Search results for: {this.props.searchQuery}</h3>
+      var resultsHeader = <h3>Search results for: '{this.props.searchQuery}'</h3>
     } 
 
     return (

--- a/src/css/NavBar.css
+++ b/src/css/NavBar.css
@@ -9,6 +9,13 @@
   overflow: hidden;
 }
 
+.navLogo {
+  font-family: "Lobster";
+  color: lightgray;
+  font-size: 2.2em;
+  padding: 5px 0 0 20px;
+}
+
 .NavBar .searchBarContainer {
   display: flex;
   z-index: 9;

--- a/src/css/NavBar.css
+++ b/src/css/NavBar.css
@@ -16,6 +16,12 @@
   padding: 5px 0 0 20px;
 }
 
+.navLogo:hover {
+  cursor: pointer;
+  color: white;
+  padding: 4px 1px 0 19px;
+}
+
 .NavBar .searchBarContainer {
   display: flex;
   z-index: 9;

--- a/src/css/SearchResults.css
+++ b/src/css/SearchResults.css
@@ -45,6 +45,11 @@
   background-color: teal;
 }
 
+.searchResults h2 {
+  margin: 80px 0 0 40px;
+  font-size: 1.8em;
+}
+
 .searchResults h3 {
   color: lightgray;
   position: fixed;


### PR DESCRIPTION
• Add Queenly logo to nav bar when not on splash page
• Refactor conditional rendering within nav bar
• Restyled no results text in search results page as to not conflict with the search query message
• Changed no results text from 'Please broaden your search' to 'No results found'
• Take user back to splash page when nav bar logo is clicked
• Add hover state to nav bar logo including a pointer cursor